### PR TITLE
`combine` command glob patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
 # doc-snippets
+
 `doc-snippets` is a simple tool that allows you to extract and inject snippets from code into markdown files.
 
 ## Installation
 
 Using NPM:
+
 ```bash
 npm install --save-dev doc-snippets
 ```
 
 Using Yarn:
+
 ```bash
 yarn add -D doc-snippets
 ```
@@ -17,31 +20,87 @@ yarn add -D doc-snippets
 
 ### Marking and injecting
 
-`doc-snippets` extracts and injects snippets by using tokens (without quotes):
-- To mark a snippet:
-  - `"$start: snippet-name"` - The start of a snippet and its name (required)
-  - `"$end"` - The end of a snippet.
-- To inject a snippet:
-  - `"$snippet: snippet-name"` - This gets replaced by the snippet with the given name.
+`doc-snippets` extracts and injects snippets by using tokens:
 
-Snippets are injected only into `.md` files.
+- To mark a snippet:
+  - `$start: snippet-name` - The start of a snippet and its name (required)
+  - `$end` - The end of a snippet.
+- To inject a snippet:
+  - `$snippet: snippet-name` - This gets replaced by the snippet with the given name.
+
+### Configuration
+
+`doc-snippets` is, by defaut, configured using a JSON file that contains a `doc-snippets` object. By default, this file is `package.json`.
+
+The configuration object has the following structure (and default values):
+
+```JSON
+"doc-snippets": {
+  "extract": {
+    "include": "./**/*.{js,ts,json,yaml,txt,md,graphql,cue}",
+    "ignore": "./**/node_modules/**",
+    "dir": "./src"
+  },
+  "inject": {
+    "include": "./**/*.md",
+    "ignore": [],
+    "dir": "./src/docs"
+  },
+  "outputDir": "./docs"
+}
+```
+
+#### `extract` and `inject`
+
+The `extract` and `inject` objects both have the same structure:
+
+- `include` - a string or array of strings containing paths to include. The paths are formatted as Glob patterns following the [node-glob specification](https://github.com/isaacs/node-glob)
+- `ignore` - same as `include`, this is a string or array of strings containing paths to ignore. It follows the same Glob pattern specification as `include`
+- `dir` - the base directory for injection and extraction. `include` and `ignore` use this directory as their base when searching for files.
+
+The `extract` object specifies which files will be parsed for snippets to extract.
+
+The `inject` object specifies which files will be copied into `outputDir` and have snippets injected into them.
+
+**Example `extract` object:**
+```JSON
+"extract": {
+  "include": ["sample.sql", "./**/*.{js,ts}"],
+  "ignore": "./**/node_modules/**",
+  "dir": "./src"
+}
+```
+In this example, `extract` will perform its search within the `./src` directory.
+
+It will include:
+- `./src/sample.sql`
+- All files within `./src` and its subdirectories ending in `.js` and `.ts`
+
+It will ignore:
+- All directories and subdirectories of any `node_modules` directory found within `./src` and its subdirectories.
+
+The same principles apply for the `inject` object.
+
+#### `outputDir`
+
+The `outputDir` is the output directory for the documentation injected with snippets.
 
 ### Running `doc-snippets`
 
-`doc-snippets` comes with a CLI tool which should handle most scenarios.
+`doc-snippets` comes with a CLI tool which is designed to handle most scenarios.
 
 The CLI `combine` is the only currently supported command, and can be used as follows:
 
 ```bash
-doc-snippets combine <snippetsDir> <docsDir> <outputDir>
-
-# Extracts snippets from ./snippets and outputs a copy of ./src/docs into ./docs with injected snippets
-doc-snippets combine ./snippets ./src/docs ./docs
+doc-snippets combine
 ```
+
+The `combine` command reads a `"doc-snippets"` section from a configuration file (by default this is `package.json`) and performs snippet extraction and injection, and outputs documentation with injected snippets into an `outputDir`.
 
 #### Options
 
-- `-i, --ignore <paths...>` - Ignore listed paths. Paths should be formatted according to the [gitignore spec 2.22.1](https://git-scm.com/docs/gitignore/2.22.1)
+- `-o, --output-dir <path>` - The output directory for injected documentation
+
   - By default, only `node_modules` is ignored.
 
 - `-e, --exts <exts...>` - Parse files with listed extensions
@@ -52,9 +111,13 @@ doc-snippets combine ./snippets ./src/docs ./docs
 If you want to use `doc-snippets` programatically, it offers two exported functions:
 
 ```typescript
-import { extractSnippets, injectSnippets } from "doc-snippets"
+import { extractSnippets, injectSnippetsIntoFile } from "doc-snippets";
 
-const snippets = await extractSnippets("./snippets") //Returns a `Record<string, string>` of all snippets found within `./snippets`.
+const snippets = await extractSnippets({
+  include: ["sample.sql", "./**/*.{js,ts}"],
+  ignore: "./**/node_modules/**",
+  dir: "./src"
+}); //Returns snippets as `Record<string, string>`.
 
-await injectSnippets(snippets, "./dest") //Injects `snippets` into .md files found inside `./dest`
+await injectSnippetsIntoFile(snippets, "./dest/readme.md"); //Injects `snippets` into `./dest/readme.md`
 ```

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
   },
   "dependencies": {
     "commander": "^9.4.1",
-    "fs-extra": "^10.1.0",
-    "ignore": "^5.2.1"
+    "glob": "^8.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-snippets",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Extract and inject snippets from code into markdown files",
   "author": {
     "name": "Pileks",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,21 @@
 import { combineDocsAndSnippets } from "./lib/combine";
+import { DocSnippetsConfig, PartialDocSnippetsConfig } from "./lib/types";
 
 import { program } from "commander";
+
+import fs from "fs";
+import { defaultDocSnippetsConfig } from "./lib/defaults";
+
+type CombineOptions = {
+  config?: string;
+  outputDir?: string;
+  extractDir?: string;
+  extractInclude?: string[];
+  extractIgnore?: string[];
+  injectDir?: string;
+  injectInclude?: string[];
+  injectIgnore?: string[];
+};
 
 export const run = async (argv: string[]): Promise<void> => {
   program.name("doc-snippets").description("Tools for documentation snippets.");
@@ -8,29 +23,88 @@ export const run = async (argv: string[]): Promise<void> => {
   program
     .command("combine")
     .description(
-      "Extracts snippets from the snippets directory and outputs a copy of the documentation directory with snippets injected into it"
+      "Extract snippets and output documentation files with snippets injected."
     )
-    .argument("<snippetsDir>", "The snippets directory")
-    .argument("<docsDir>", "The documentation directory")
-    .argument("<outputDir>", "The output directory")
-    .option("-i, --ignore <paths...>", "Ignore specified paths")
-    .option("-e, --exts <exts...>", "Extensions to parse")
-    .action(
-      async (
-        snippetsDir: string,
-        docsDir: string,
-        outputDir: string,
-        { ignore, exts }
-      ) => {
-        await combineDocsAndSnippets(
-          snippetsDir,
-          docsDir,
-          outputDir,
-          exts,
-          ignore
-        );
-      }
-    );
+    .option(
+      "-c --config <path>",
+      "Path to configuration file (default: './package.json')"
+    )
+    .option("-o --output-dir <path>", "Combined documentation output directory")
+    .option(
+      "--extract-dir <path>",
+      "The base directory within which to search for snippets"
+    )
+    .option(
+      "--extract-include <paths...>",
+      "Include specified paths or glob patterns in snippet extraction"
+    )
+    .option(
+      "--extract-ignore <paths...>",
+      "Ignore specified paths or glob patterns in snippet extraction"
+    )
+    .option(
+      "--inject-dir <path>",
+      "The base directory within which to search for injectable files"
+    )
+    .option(
+      "--inject-include <paths...>",
+      "Include specified paths or glob patterns in snippet injection"
+    )
+    .option(
+      "--inject-ignore <paths...>",
+      "Ignore specified paths or glob patterns in snippet injection"
+    )
+    .action(async (options: CombineOptions) => {
+      const configFilePath = options.config ?? "./package.json";
+      const config = parseDocSnippetsConfig(configFilePath);
+
+      applyCommandOptionsToConfig(options, config);
+
+      await combineDocsAndSnippets(config);
+    });
 
   await program.parseAsync(argv);
 };
+
+function parseDocSnippetsConfig(configFilePath: string): DocSnippetsConfig {
+  const configFileContents = fs.readFileSync(configFilePath, {
+    encoding: "utf-8",
+  });
+
+  const configJson = JSON.parse(configFileContents);
+
+  const config = configJson["doc-snippets"] as PartialDocSnippetsConfig;
+
+  const resultConfig: DocSnippetsConfig = {
+    extract: {
+      dir: config.extract?.dir ?? defaultDocSnippetsConfig.extract.dir,
+      ignore: config.extract?.ignore ?? defaultDocSnippetsConfig.extract.ignore,
+      include:
+        config.extract?.include ?? defaultDocSnippetsConfig.extract.include,
+    },
+    inject: {
+      dir: config.inject?.dir ?? defaultDocSnippetsConfig.inject.dir,
+      ignore: config.inject?.ignore ?? defaultDocSnippetsConfig.inject.ignore,
+      include:
+        config.inject?.include ?? defaultDocSnippetsConfig.inject.include,
+    },
+    outputDir: config.outputDir ?? defaultDocSnippetsConfig.outputDir,
+  };
+
+  return resultConfig;
+}
+
+function applyCommandOptionsToConfig(
+  options: CombineOptions,
+  config: DocSnippetsConfig
+) {
+  config.extract.dir = options.extractDir ?? config.extract.dir;
+  config.extract.include = options.extractInclude ?? config.extract.include;
+  config.extract.ignore = options.extractIgnore ?? config.extract.ignore;
+
+  config.inject.dir = options.extractDir ?? config.inject.dir;
+  config.inject.include = options.extractInclude ?? config.inject.include;
+  config.inject.ignore = options.extractIgnore ?? config.inject.ignore;
+
+  config.outputDir = options.outputDir ?? config.outputDir;
+}

--- a/src/lib/defaults/defaultDocSnippetsConfig.ts
+++ b/src/lib/defaults/defaultDocSnippetsConfig.ts
@@ -1,0 +1,15 @@
+import { DocSnippetsConfig } from "../types";
+
+export const defaultDocSnippetsConfig: DocSnippetsConfig = {
+  extract: {
+    dir: "./src",
+    include: "./**/*.{js,ts,json,yaml,txt,md,graphql,cue}",
+    ignore: ["./**/node_modules/**"],
+  },
+  inject: {
+    dir: "./src/docs",
+    include: "./**/*.{md}",
+    ignore: ["./**/node_modules/**"],
+  },
+  outputDir: "./docs"
+}

--- a/src/lib/defaults/defaultDocSnippetsConfig.ts
+++ b/src/lib/defaults/defaultDocSnippetsConfig.ts
@@ -4,12 +4,12 @@ export const defaultDocSnippetsConfig: DocSnippetsConfig = {
   extract: {
     dir: "./src",
     include: "./**/*.{js,ts,json,yaml,txt,md,graphql,cue}",
-    ignore: ["./**/node_modules/**"],
+    ignore: "./**/node_modules/**",
   },
   inject: {
     dir: "./src/docs",
-    include: "./**/*.{md}",
-    ignore: ["./**/node_modules/**"],
+    include: "./**/*.md",
+    ignore: "./**/node_modules/**",
   },
   outputDir: "./docs"
 }

--- a/src/lib/defaults/defaultIgnorePaths.ts
+++ b/src/lib/defaults/defaultIgnorePaths.ts
@@ -1,1 +1,0 @@
-export const defaultIgnorePaths = ["node_modules"];

--- a/src/lib/defaults/defaultParseExts.ts
+++ b/src/lib/defaults/defaultParseExts.ts
@@ -1,9 +1,0 @@
-export const defaultParseExts = [
-  ".ts",
-  ".json",
-  ".yaml",
-  ".txt",
-  ".md",
-  ".graphql",
-  ".cue",
-];

--- a/src/lib/defaults/index.ts
+++ b/src/lib/defaults/index.ts
@@ -1,2 +1,1 @@
-export * from "./defaultIgnorePaths";
-export * from "./defaultParseExts";
+export * from './defaultDocSnippetsConfig';

--- a/src/lib/inject.ts
+++ b/src/lib/inject.ts
@@ -1,41 +1,6 @@
-import path from "path";
 import fs from "fs";
 
-/**
- * Inject snippets into .md files within a directory
- * @param {Record<string, string>} snippets - The snippets to inject
- * @param {string} dir - The directory containing .md files
- * @returns
- */
-export async function injectSnippets(
-  snippets: Record<string, string>,
-  dir: string
-): Promise<void> {
-  const dirents = fs.readdirSync(dir, { withFileTypes: true });
-
-  // Only search specific types of files
-  const exts = ["md"];
-  const matchExt = (filename: string) => {
-    for (const ext of exts) {
-      if (filename.indexOf(`.${ext}`) > -1) {
-        return true;
-      }
-    }
-    return false;
-  };
-
-  for (const dirent of dirents) {
-    const direntPath = path.join(dir, dirent.name);
-
-    if (dirent.isFile() && matchExt(dirent.name)) {
-      await injectSnippetIntoFile(snippets, direntPath);
-    } else if (dirent.isDirectory()) {
-      await injectSnippets(snippets, direntPath);
-    }
-  }
-}
-
-async function injectSnippetIntoFile(
+export async function injectSnippetsIntoFile(
   snippets: Record<string, string>,
   filePath: string
 ) {
@@ -54,7 +19,7 @@ async function injectSnippetIntoFile(
 
     const nameStartIdx = markerIdx + marker.length;
     const nameEndIdx = contents.indexOf("\n", nameStartIdx);
-    const name = contents.substr(nameStartIdx, nameEndIdx - nameStartIdx);
+    const name = contents.substring(nameStartIdx, nameEndIdx);
 
     if (!snippets[name]) {
       throw Error(`Unknown Snippet: ${name} in ${filePath}`);

--- a/src/lib/types/docSnippetsConfig.ts
+++ b/src/lib/types/docSnippetsConfig.ts
@@ -1,0 +1,13 @@
+import { SearchOptions } from ".";
+
+export type DocSnippetsConfig = {
+  extract: SearchOptions;
+  inject: SearchOptions;
+  outputDir: string;
+};
+
+export type PartialDocSnippetsConfig = {
+  extract?: Partial<SearchOptions>;
+  inject?: Partial<SearchOptions>;
+  outputDir?: string;
+}

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -1,0 +1,2 @@
+export * from './docSnippetsConfig';
+export * from './searchOptions';

--- a/src/lib/types/searchOptions.ts
+++ b/src/lib/types/searchOptions.ts
@@ -1,0 +1,7 @@
+export type SearchPattern = string | string[];
+
+export type SearchOptions = {
+  dir: string;
+  include: SearchPattern;
+  ignore: SearchPattern;
+};

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './searchFiles';

--- a/src/lib/utils/searchFiles.ts
+++ b/src/lib/utils/searchFiles.ts
@@ -1,0 +1,28 @@
+import glob from "glob";
+import { SearchOptions, SearchPattern } from "../types";
+
+export function searchFiles(options: SearchOptions): string[] {
+  let results: string[];
+
+  if (typeof options.include === "string") {
+    results = findFilePathsWithinDir(
+      options.include,
+      options.dir,
+      options.ignore
+    );
+  } else {
+    results = options.include.flatMap((pattern) =>
+      findFilePathsWithinDir(pattern, options.dir, options.ignore)
+    );
+  }
+
+  return results;
+}
+
+function findFilePathsWithinDir(
+  globPattern: string,
+  dir: string,
+  ignore?: SearchPattern
+): string[] {
+  return glob.sync(globPattern, { ignore: ignore, cwd: dir });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -306,6 +306,13 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
+brace-expansion@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
+  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
+  dependencies:
+    balanced-match "^1.0.0"
+
 braces@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
@@ -716,15 +723,6 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
-fs-extra@^10.1.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.1.0.tgz#02873cfbc4084dde127eaa5f9905eef2325d1abf"
-  integrity sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==
-  dependencies:
-    graceful-fs "^4.2.0"
-    jsonfile "^6.0.1"
-    universalify "^2.0.0"
-
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -793,6 +791,17 @@ glob@^7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@^8.0.3:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-8.0.3.tgz#415c6eb2deed9e502c68fa44a272e6da6eeca42e"
+  integrity sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^5.0.1"
+    once "^1.3.0"
+
 globals@^13.15.0:
   version "13.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-13.18.0.tgz#fb224daeeb2bb7d254cd2c640f003528b8d0c1dc"
@@ -811,11 +820,6 @@ globby@^11.1.0:
     ignore "^5.2.0"
     merge2 "^1.4.1"
     slash "^3.0.0"
-
-graceful-fs@^4.1.6, graceful-fs@^4.2.0:
-  version "4.2.10"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
-  integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
 grapheme-splitter@^1.0.4:
   version "1.0.4"
@@ -862,11 +866,6 @@ ignore@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
-
-ignore@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.1.tgz#c2b1f76cb999ede1502f3a226a9310fdfe88d46c"
-  integrity sha512-d2qQLzTJ9WxQftPAuEQpSPmKqzxePjzVbpAVv62AQ64NTL+wR4JkrVqR/LqFsFEUsHDAiId52mJteHDFuDkElA==
 
 import-fresh@^3.0.0, import-fresh@^3.2.1:
   version "3.3.0"
@@ -1041,15 +1040,6 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
-jsonfile@^6.0.1:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
-  integrity sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
-  dependencies:
-    universalify "^2.0.0"
-  optionalDependencies:
-    graceful-fs "^4.1.6"
-
 levn@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz#ae4562c007473b932a6200d403268dd2fffc6ade"
@@ -1101,6 +1091,13 @@ minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
+
+minimatch@^5.0.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.1.tgz#6c9dffcf9927ff2a31e74b5af11adf8b9604b022"
+  integrity sha512-362NP+zlprccbEt/SkxKfRMHnNY85V74mVnpUpNyr3F35covl09Kec7/sEFLt3RA4oXmewtoaanoIf67SE5Y5g==
+  dependencies:
+    brace-expansion "^2.0.1"
 
 minimist@^1.2.0, minimist@^1.2.6:
   version "1.2.7"
@@ -1473,11 +1470,6 @@ unbox-primitive@^1.0.2:
     has-bigints "^1.0.2"
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
-
-universalify@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
-  integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
 
 uri-js@^4.2.2:
   version "4.4.1"


### PR DESCRIPTION
Closes #3 

This PR rewrites the `combine` command completely. 

The old system of directories, extensions and ignores is replaced with a universal "search" system which uses `include` and `ignore` glob patterns (single or multiple), with an addition of a "base directory" within which searches can be performed.

This will allow developers to determine the files for extraction and injection in a much more flexible, and more importantly precise manner.

Configuration of the `combine` command can now be done via `package.json`, or any other JSON file which has the appropriate `doc-snippets` object defined within it.

The `combine` command now has no more arguments - any configuration you want to change is now changeable via options, although the primary use-case is now configuring `doc-snippets` via the config file.

A full example of this can now be found in https://github.com/polywrap/documentation/pull/237

Remaining work:
- [x] Update README